### PR TITLE
[Blender] Support bundled ZIP format distrubtion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ htmlcov
 *.xml
 *.zip
 blender/engine
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ htmlcov
 *.xml
 *.zip
 blender/engine
-build/
+/build

--- a/blender/__init__.py
+++ b/blender/__init__.py
@@ -27,19 +27,14 @@ if use_blender:
     import sys
     import os
 
-    use_bundle = False
+    bundle_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'bundle')
 
-    for p in sys.path:
-        bundle_path = os.path.join(p, 'Taichi-Elements', 'bundle')
-        if os.path.exists(bundle_path):
-            use_bundle = True
-            break
-
-    if use_bundle:
+    if os.path.exists(bundle_path):
         def register():
             print('Found Taichi-Elements/bundle at', bundle_path)
             if bundle_path not in sys.path:
                 sys.path.insert(0, bundle_path)
+            # import addon after path is inserted, so that `import taichi` works
             from . import addon
             addon.register()
 

--- a/blender/__init__.py
+++ b/blender/__init__.py
@@ -45,7 +45,7 @@ if use_blender:
                 sys.path.remove(bundle_path)
 
     else:
-        print('Cannot find Taichi-Elements/bundle, assuming PyPI install.')
+        print('Cannot find Taichi-Elements/bundle, assuming PyPI installation.')
 
         from . import addon
 

--- a/blender/__init__.py
+++ b/blender/__init__.py
@@ -24,12 +24,40 @@ except:
     pass
 
 if use_blender:
-    from . import addon
+    import sys
+    import os
 
-    def register():
-        addon.register()
+    use_bundle = False
 
-    def unregister():
-        addon.unregister()
+    for p in sys.path:
+        bundle_path = os.path.join(p, 'Taichi-Elements', 'bundle')
+        if os.path.exists(bundle_path):
+            use_bundle = True
+            break
+
+    if use_bundle:
+        def register():
+            print('Found Taichi-Elements/bundle at', bundle_path)
+            if bundle_path not in sys.path:
+                sys.path.insert(0, bundle_path)
+            from . import addon
+            addon.register()
+
+        def unregister():
+            from . import addon
+            addon.unregister()
+            if bundle_path in sys.path:
+                sys.path.remove(bundle_path)
+
+    else:
+        print('Cannot find Taichi-Elements/bundle, assuming PyPI install.')
+
+        from . import addon
+
+        def register():
+            addon.register()
+
+        def unregister():
+            addon.unregister()
 
 # Otherwise act as a PyPI package

--- a/blender/requirements.txt
+++ b/blender/requirements.txt
@@ -1,0 +1,6 @@
+astor
+colorama
+dill
+pybind11>=2.5.0
+sourceinspect>=0.0.3
+taichi

--- a/make_bundle.sh
+++ b/make_bundle.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+mkdir -p build/Taichi-Elements/bundle
+python3 -m pip install taichi -t build/Taichi-Elements/bundle
+cp -r blender/* build/Taichi-Elements
+cp -r engine build/Taichi-Elements
+rm -f build/Taichi-Elements.zip
+cd build && zip -r Taichi-Elements.zip Taichi-Elements

--- a/make_bundle.sh
+++ b/make_bundle.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 set -e
+rm -rf build/Taichi-Elements
 mkdir -p build/Taichi-Elements/bundle
-python3 -m pip install taichi -t build/Taichi-Elements/bundle
+python3 -m pip install --no-deps -r blender/requirements.txt -t build/Taichi-Elements/bundle
 cp -r blender/* build/Taichi-Elements
 cp -r engine build/Taichi-Elements
+rm -rf build/Taichi-Elements/bundle/include
+rm -rf build/Taichi-Elements/bundle/*.dist-info
+rm -rf build/Taichi-Elements/bundle/bin
 rm -f build/Taichi-Elements.zip
 cd build && zip -r Taichi-Elements.zip Taichi-Elements


### PR DESCRIPTION
Related issue = close #59

This allows users to install Taichi Elements like a trivial addon, like `Stop-Motion-OBJ.zip` does.
All the dependencies are included in `Taichi-Elements.zip/bundle`, which will be added to `sys.path`.